### PR TITLE
Support for saving and applying presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,32 @@ duotone --help
 
 ## Usage
 
+Duotone individual files or batch process entire folders.
+
 ```bash
 # Single Image...
 duotone input.jpg --light '#FFCB00' --dark '#38046C' --out output.png
 
 # Batch processing...
 duotone ~/images --light '#FFCB00' --dark '#38046C' --out ~/images/out
+```
+
+## Presets
+
+Settings can be saved as preset so they can be reused without having to juggle or memorize hex colors.
+
+```bash
+# List all presets
+duotone list
+
+# Add a new preset named 'foo'
+duotone add --preset foo --light '#FFCB00' --dark '#38046C' --contrast 0.5 --blend 0.5
+
+# Remove the preset named foo
+duotone remove --preset foo
+
+# Apply the preset 'foo' to 'file.jpg'
+duotone file.jpg --preset foo --out result.jpg
 ```
 
 ## License

--- a/Sources/duotone/Presets/Add.swift
+++ b/Sources/duotone/Presets/Add.swift
@@ -51,7 +51,7 @@ extension Duotone {
             var presets = try Duotone.loadPresets()
             let exists = presets.contains { $0.name == preset.name }
             if exists {
-                throw "A preset with the name '\(preset.name)' already exists"
+                throw ValidationError("A preset with the name '\(preset.name)' already exists")
             }
             presets.append(preset)
             try Duotone.savePresets(presets)

--- a/Sources/duotone/Presets/Add.swift
+++ b/Sources/duotone/Presets/Add.swift
@@ -14,7 +14,7 @@ extension Duotone {
         static var configuration = CommandConfiguration(abstract: "Add a presets.")
 
         @Option(name: .long, help: "The name of the preset")
-        var name: String
+        var preset: String
 
         @Option(name: [.short, .customLong("light")], help: "The lightest color in hex")
         var lightHexOption: String
@@ -41,7 +41,7 @@ extension Duotone {
             var blend = (blendOption != nil) ? CGFloat(blendOption!) : 1.0
             if blend > 1.0 { blend = 1.0 } else if blend < 0.0 { blend = 0.0 }
 
-            let preset = Preset(name: name,
+            let preset = Preset(name: preset,
                                 light: lightColor.toHexString(),
                                 dark: darkColor.toHexString(),
                                 contrast: contrast,

--- a/Sources/duotone/Presets/Add.swift
+++ b/Sources/duotone/Presets/Add.swift
@@ -1,0 +1,61 @@
+//
+//  Add.swift
+//  ArgumentParser
+//
+//  Created by Carlo Eugster on 05.07.21.
+//
+
+import AppKit
+import ArgumentParser
+import Files
+
+extension Duotone {
+    struct Add: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "Add a presets.")
+
+        @Option(name: .long, help: "The name of the preset")
+        var name: String
+
+        @Option(name: [.short, .customLong("light")], help: "The lightest color in hex")
+        var lightHexOption: String
+
+        @Option(name: [.short, .customLong("dark")], help: "The darkest color in hex")
+        var darkHexOption: String
+
+        @Option(name: [.short, .customLong("contrast")], help: "Contrast value between 0.0 and 1.0")
+        var contrastOption: Float?
+
+        @Option(name: [.short, .customLong("blend")], help: "Blend value between 0.0 and 1.0")
+        var blendOption: Float?
+
+        @Option(name: .long, help: "An optional description of the preset")
+        var description: String?
+
+        mutating func run() throws {
+            let lightColor = try NSColor(hex: lightHexOption)
+            let darkColor = try NSColor(hex: darkHexOption)
+
+            var contrast = (contrastOption != nil) ? CGFloat(contrastOption!) : 0.5
+            if contrast > 1.0 { contrast = 1.0 } else if contrast < 0.0 { contrast = 0.0 }
+
+            var blend = (blendOption != nil) ? CGFloat(blendOption!) : 1.0
+            if blend > 1.0 { blend = 1.0 } else if blend < 0.0 { blend = 0.0 }
+
+            let preset = Preset(name: name,
+                                light: lightColor.toHexString(),
+                                dark: darkColor.toHexString(),
+                                contrast: contrast,
+                                blend: blend,
+                                description: description)
+
+            var presets = try Duotone.loadPresets()
+            let exists = presets.contains { $0.name == preset.name }
+            if exists {
+                throw "A preset with the name '\(preset.name)' already exists"
+            }
+            presets.append(preset)
+            try Duotone.savePresets(presets)
+            print("Added '\(preset.name)'")
+        }
+    }
+}

--- a/Sources/duotone/Presets/List.swift
+++ b/Sources/duotone/Presets/List.swift
@@ -1,0 +1,23 @@
+//
+//  List.swift
+//  duotone
+//
+//  Created by Carlo Eugster on 05.07.21.
+//
+
+import AppKit
+import ArgumentParser
+import Files
+
+extension Duotone {
+    struct List: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "List all presets.")
+
+        mutating func run() throws {
+            let presets = try Duotone.loadPresets()
+            for preset in presets {
+                print("Name: \(preset.name) - Light: \(preset.light), Dark: \(preset.dark), Contrast: \(preset.contrast), Blend: \(preset.blend)")
+            }
+        }
+    }
+}

--- a/Sources/duotone/Presets/Loader.swift
+++ b/Sources/duotone/Presets/Loader.swift
@@ -1,0 +1,32 @@
+//
+//  Loader.swift
+//  duotone
+//
+//  Created by Carlo Eugster on 05.07.21.
+//
+
+import ArgumentParser
+import Files
+import Foundation
+
+private let presetLocation = "~/.duotone"
+
+extension Duotone {
+    static func loadPresets() throws -> [Preset] {
+        guard let file = try? File(path: presetLocation) else {
+            return [Preset]()
+        }
+        guard let data = try? Data(contentsOf: file.url) else {
+            throw "Could not read the preset file: \(presetLocation)."
+        }
+        return try JSONDecoder().decode([Preset].self, from: data)
+    }
+
+    static func savePresets(_ presets: [Preset]) throws {
+        let file = try File(path: presetLocation)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let data = try encoder.encode(presets)
+        try file.write(data)
+    }
+}

--- a/Sources/duotone/Presets/Loader.swift
+++ b/Sources/duotone/Presets/Loader.swift
@@ -17,7 +17,7 @@ extension Duotone {
             return [Preset]()
         }
         guard let data = try? Data(contentsOf: file.url) else {
-            throw "Could not read the preset file: \(presetLocation)."
+            throw ValidationError("Could not read the preset file: \(presetLocation).")
         }
         return try JSONDecoder().decode([Preset].self, from: data)
     }

--- a/Sources/duotone/Presets/Preset.swift
+++ b/Sources/duotone/Presets/Preset.swift
@@ -1,0 +1,17 @@
+//
+//  Preset.swift
+//  ArgumentParser
+//
+//  Created by Carlo Eugster on 05.07.21.
+//
+
+import Foundation
+
+struct Preset: Codable {
+    var name: String
+    var light: String
+    var dark: String
+    var contrast: CGFloat
+    var blend: CGFloat
+    var description: String?
+}

--- a/Sources/duotone/Presets/Remove.swift
+++ b/Sources/duotone/Presets/Remove.swift
@@ -1,0 +1,31 @@
+//
+//  Remove.swift
+//  duotone
+//
+//  Created by Carlo Eugster on 05.07.21.
+//
+
+import Foundation
+
+import AppKit
+import ArgumentParser
+import Files
+
+extension Duotone {
+    struct Remove: ParsableCommand {
+        static var configuration = CommandConfiguration(abstract: "Remove a presets.")
+
+        @Option(name: .long, help: "The name of the preset")
+        var name: String
+
+        mutating func run() throws {
+            let presets = try Duotone.loadPresets()
+            let filtered = presets.filter { $0.name != name}
+            if presets.count == filtered.count {
+                throw "No existing preset with name '\(name)' found"
+            }
+            try Duotone.savePresets(filtered)
+            print("Removed '\(name)'")
+        }
+    }
+}

--- a/Sources/duotone/Presets/Remove.swift
+++ b/Sources/duotone/Presets/Remove.swift
@@ -22,7 +22,7 @@ extension Duotone {
             let presets = try Duotone.loadPresets()
             let filtered = presets.filter { $0.name != name}
             if presets.count == filtered.count {
-                throw "No existing preset with name '\(name)' found"
+                throw ValidationError("No existing preset with name '\(name)' found")
             }
             try Duotone.savePresets(filtered)
             print("Removed '\(name)'")

--- a/Sources/duotone/Presets/Remove.swift
+++ b/Sources/duotone/Presets/Remove.swift
@@ -16,16 +16,16 @@ extension Duotone {
         static var configuration = CommandConfiguration(abstract: "Remove a presets.")
 
         @Option(name: .long, help: "The name of the preset")
-        var name: String
+        var preset: String
 
         mutating func run() throws {
             let presets = try Duotone.loadPresets()
-            let filtered = presets.filter { $0.name != name}
+            let filtered = presets.filter { $0.name != preset}
             if presets.count == filtered.count {
-                throw ValidationError("No existing preset with name '\(name)' found")
+                throw ValidationError("No existing preset with name '\(preset)' found")
             }
             try Duotone.savePresets(filtered)
-            print("Removed '\(name)'")
+            print("Removed '\(preset)'")
         }
     }
 }

--- a/Sources/duotone/main.swift
+++ b/Sources/duotone/main.swift
@@ -14,7 +14,7 @@ private let validImageExtensions = ["jpg", "jpeg", "png"]
 struct Duotone: ParsableCommand {
     static var configuration = CommandConfiguration(
         abstract: "A utility for duotoning images.",
-        subcommands: [Process.self, Add.self, Remove.self],
+        subcommands: [Process.self, Add.self, Remove.self, List.self],
         defaultSubcommand: Process.self)
 }
 

--- a/Sources/duotone/main.swift
+++ b/Sources/duotone/main.swift
@@ -25,8 +25,8 @@ extension Duotone {
         @Argument(help: "The source file or folder")
         var inputPath: String
 
-        @Flag(name: .shortAndLong, help: "Print verbose output")
-        var verbose = false
+        @Option(name: [.short, .customLong("preset")], help: "The name of a preset")
+        var presetName: String?
 
         @Option(name: [.short, .customLong("light")], help: "The lightest color in hex")
         var lightHexOption: String
@@ -39,6 +39,9 @@ extension Duotone {
 
         @Option(name: [.short, .customLong("blend")], help: "Blend value between 0.0 and 1.0")
         var blendOption: Float?
+
+        @Flag(name: .shortAndLong, help: "Print verbose output")
+        var verbose = false
 
         @Option(name: [.short, .customLong("out")], help: "Path where the output files are saved")
         var outputPath: String
@@ -57,11 +60,11 @@ extension Duotone {
 
             if verbose {
                 print("-[Settings]----------------------")
-                print("   📁 Source:   \(inputPath)")
-                print("   🎨 Light:    \(lightColor.toHexString())")
-                print("   🎨 Dark:     \(darkColor.toHexString())")
-                print("   🎛️ Contrast:  \(contrast)")
-                print("   🎛️ Blend:     \(blend)")
+                print(" - 📁 Source:   \(inputPath)")
+                print(" - 🎨 Light:    \(lightColor.toHexString())")
+                print(" - 🎨 Dark:     \(darkColor.toHexString())")
+                print(" - 🎛️ Contrast: \(contrast)")
+                print(" - 🎛️ Blend:    \(blend)")
                 print("---------------------------------\n")
                 print("🔎 Scanning '\(inputPath)'...")
             }

--- a/Sources/duotone/main.swift
+++ b/Sources/duotone/main.swift
@@ -14,7 +14,7 @@ private let validImageExtensions = ["jpg", "jpeg", "png"]
 struct Duotone: ParsableCommand {
     static var configuration = CommandConfiguration(
         abstract: "A utility for duotoning images.",
-        subcommands: [Process.self, Add.self],
+        subcommands: [Process.self, Add.self, Remove.self],
         defaultSubcommand: Process.self)
 }
 


### PR DESCRIPTION
Adds support for preset commands...

Managing presets:
- `duotone add --preset foo --light '#FFCB00' --dark '#38046C' --contrast 1.0 --blend 0.5` adds a new preset called 'foo'.
- `duotone remove --preset foo` removes the preset with name 'foo'
- `duotone list` lists all presets.

Using presets:
- `duotone ~/some/file.jpg --preset foo --out ~/my/processed/file.jpg`