### PR TITLE
Improve test coverage on non-Metal code paths

### DIFF
--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -73,10 +73,13 @@ extension Duotone {
         }
 
         private func preset() throws -> Preset {
+            let existing = presetName != nil ? try Duotone.loadPresets() : []
+            return try resolvePreset(from: existing)
+        }
+
+        func resolvePreset(from existing: [Preset]) throws -> Preset {
             if let presetName = presetName {
-                let presets = try Duotone.loadPresets()
-                let preset = presets.first { $0.name == presetName }
-                guard let preset = preset else {
+                guard let preset = existing.first(where: { $0.name == presetName }) else {
                     throw ValidationError("No preset with name '\(presetName)' found.")
                 }
                 if verbose {

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -130,7 +130,7 @@ extension Duotone {
             return outputFolder
         }
 
-        private func processInput() throws -> [File] {
+        func processInput() throws -> [File] {
             if let file = try? File(path: inputPath) {
                 if let ext = file.extension, FileFormat.allValidExtensions.contains(ext) {
                     return [file]

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -13,7 +13,7 @@ struct DuotoneError: Error, CustomStringConvertible {
 struct Duotone: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for duotoning images.",
-        version: "1.1.0",
+        version: "1.1.1",
         subcommands: [Process.self, Add.self, Remove.self, List.self],
         defaultSubcommand: Process.self)
 }

--- a/Sources/duotone/Presets/Add.swift
+++ b/Sources/duotone/Presets/Add.swift
@@ -32,27 +32,30 @@ extension Duotone {
         var description: String?
 
         mutating func run() throws {
+            let presets = try Duotone.loadPresets()
+            let updated = try addingPreset(to: presets)
+            try Duotone.savePresets(updated)
+            print("Added '\(preset)'")
+        }
+
+        func addingPreset(to existing: [Preset]) throws -> [Preset] {
             let lightColor = try NSColor(hex: lightHexOption)
             let darkColor = try NSColor(hex: darkHexOption)
 
             let contrast = CGFloat(contrastOption ?? 0.5).clamped(to: 0...1)
             let blend = CGFloat(blendOption ?? 1.0).clamped(to: 0...1)
 
-            let preset = Preset(name: preset,
-                                light: lightColor.toHexString(),
-                                dark: darkColor.toHexString(),
-                                contrast: contrast,
-                                blend: blend,
-                                description: description)
+            let newPreset = Preset(name: preset,
+                                   light: lightColor.toHexString(),
+                                   dark: darkColor.toHexString(),
+                                   contrast: contrast,
+                                   blend: blend,
+                                   description: description)
 
-            var presets = try Duotone.loadPresets()
-            let exists = presets.contains { $0.name == preset.name }
-            if exists {
-                throw ValidationError("A preset with the name '\(preset.name)' already exists")
+            if existing.contains(where: { $0.name == newPreset.name }) {
+                throw ValidationError("A preset with the name '\(newPreset.name)' already exists")
             }
-            presets.append(preset)
-            try Duotone.savePresets(presets)
-            print("Added '\(preset.name)'")
+            return existing + [newPreset]
         }
     }
 }

--- a/Sources/duotone/Presets/Remove.swift
+++ b/Sources/duotone/Presets/Remove.swift
@@ -18,12 +18,17 @@ extension Duotone {
 
         mutating func run() throws {
             let presets = try Duotone.loadPresets()
-            let filtered = presets.filter { $0.name != preset}
-            if presets.count == filtered.count {
-                throw ValidationError("No existing preset with name '\(preset)' found")
-            }
+            let filtered = try removingPreset(from: presets)
             try Duotone.savePresets(filtered)
             print("Removed '\(preset)'")
+        }
+
+        func removingPreset(from existing: [Preset]) throws -> [Preset] {
+            let filtered = existing.filter { $0.name != preset }
+            if existing.count == filtered.count {
+                throw ValidationError("No existing preset with name '\(preset)' found")
+            }
+            return filtered
         }
     }
 }

--- a/Tests/duotoneTests/AddRemoveTests.swift
+++ b/Tests/duotoneTests/AddRemoveTests.swift
@@ -1,0 +1,108 @@
+//
+//  AddRemoveTests.swift
+//  duotoneTests
+//
+
+import XCTest
+@testable import duotone
+
+class AddRemoveTests: XCTestCase {
+
+    // MARK: Add
+
+    func testAdd_appendsPresetToEmptyList() throws {
+        let add = try Duotone.Add.parse([
+            "--preset", "spacegray",
+            "-l", "#444644",
+            "-d", "#1E201E"
+        ])
+        let updated = try add.addingPreset(to: [])
+        XCTAssertEqual(updated.count, 1)
+        XCTAssertEqual(updated[0].name, "spacegray")
+        XCTAssertEqual(updated[0].light, "#444644")
+        XCTAssertEqual(updated[0].dark, "#1E201E")
+        XCTAssertEqual(updated[0].contrast, 0.5) // default
+        XCTAssertEqual(updated[0].blend, 1.0)    // default
+        XCTAssertNil(updated[0].description)
+    }
+
+    func testAdd_appendsToNonEmptyList() throws {
+        let existing = [Preset(name: "duke", light: "#FFCB00", dark: "#38046C", contrast: 0.5, blend: 1.0, description: nil)]
+        let add = try Duotone.Add.parse([
+            "--preset", "spacegray",
+            "-l", "#444644",
+            "-d", "#1E201E"
+        ])
+        let updated = try add.addingPreset(to: existing)
+        XCTAssertEqual(updated.count, 2)
+        XCTAssertEqual(updated[0].name, "duke")
+        XCTAssertEqual(updated[1].name, "spacegray")
+    }
+
+    func testAdd_throwsWhenNameAlreadyExists() throws {
+        let existing = [Preset(name: "spacegray", light: "#444644", dark: "#1E201E", contrast: 0.5, blend: 1.0, description: nil)]
+        let add = try Duotone.Add.parse([
+            "--preset", "spacegray",
+            "-l", "#FFFFFF",
+            "-d", "#000000"
+        ])
+        XCTAssertThrowsError(try add.addingPreset(to: existing))
+    }
+
+    func testAdd_clampsContrastAndBlend() throws {
+        let add = try Duotone.Add.parse([
+            "--preset", "x",
+            "-l", "#FFFFFF",
+            "-d", "#000000",
+            "--contrast=1.5",
+            "--blend=-0.25"
+        ])
+        let updated = try add.addingPreset(to: [])
+        XCTAssertEqual(updated[0].contrast, 1.0)
+        XCTAssertEqual(updated[0].blend, 0.0)
+    }
+
+    func testAdd_persistsDescription() throws {
+        let add = try Duotone.Add.parse([
+            "--preset", "duke",
+            "-l", "#FFCB00",
+            "-d", "#38046C",
+            "--description", "duke nukem"
+        ])
+        let updated = try add.addingPreset(to: [])
+        XCTAssertEqual(updated[0].description, "duke nukem")
+    }
+
+    func testAdd_throwsOnInvalidLightHex() throws {
+        let add = try Duotone.Add.parse([
+            "--preset", "x",
+            "-l", "not-a-hex",
+            "-d", "#000000"
+        ])
+        XCTAssertThrowsError(try add.addingPreset(to: []))
+    }
+
+    // MARK: Remove
+
+    func testRemove_filtersMatchingName() throws {
+        let existing = [
+            Preset(name: "a", light: "#FFFFFF", dark: "#000000", contrast: 0.5, blend: 1.0, description: nil),
+            Preset(name: "b", light: "#FF0000", dark: "#00FF00", contrast: 0.5, blend: 1.0, description: nil)
+        ]
+        let remove = try Duotone.Remove.parse(["--preset", "a"])
+        let filtered = try remove.removingPreset(from: existing)
+        XCTAssertEqual(filtered.count, 1)
+        XCTAssertEqual(filtered[0].name, "b")
+    }
+
+    func testRemove_throwsWhenNameNotFound() throws {
+        let existing = [Preset(name: "a", light: "#FFFFFF", dark: "#000000", contrast: 0.5, blend: 1.0, description: nil)]
+        let remove = try Duotone.Remove.parse(["--preset", "missing"])
+        XCTAssertThrowsError(try remove.removingPreset(from: existing))
+    }
+
+    func testRemove_throwsOnEmptyList() throws {
+        let remove = try Duotone.Remove.parse(["--preset", "anything"])
+        XCTAssertThrowsError(try remove.removingPreset(from: []))
+    }
+}

--- a/Tests/duotoneTests/ClampedTests.swift
+++ b/Tests/duotoneTests/ClampedTests.swift
@@ -1,0 +1,33 @@
+//
+//  ClampedTests.swift
+//  duotoneTests
+//
+
+import XCTest
+@testable import duotone
+
+class ClampedTests: XCTestCase {
+
+    func testClampedReturnsValueWhenWithinRange() {
+        XCTAssertEqual(0.5.clamped(to: 0.0...1.0), 0.5)
+    }
+
+    func testClampedReturnsLowerBoundWhenBelow() {
+        XCTAssertEqual((-0.25).clamped(to: 0.0...1.0), 0.0)
+    }
+
+    func testClampedReturnsUpperBoundWhenAbove() {
+        XCTAssertEqual(1.75.clamped(to: 0.0...1.0), 1.0)
+    }
+
+    func testClampedAtBoundsReturnsBounds() {
+        XCTAssertEqual(0.0.clamped(to: 0.0...1.0), 0.0)
+        XCTAssertEqual(1.0.clamped(to: 0.0...1.0), 1.0)
+    }
+
+    func testClampedWorksForIntegers() {
+        XCTAssertEqual(5.clamped(to: 0...10), 5)
+        XCTAssertEqual((-3).clamped(to: 0...10), 0)
+        XCTAssertEqual(99.clamped(to: 0...10), 10)
+    }
+}

--- a/Tests/duotoneTests/FileFormatTests.swift
+++ b/Tests/duotoneTests/FileFormatTests.swift
@@ -60,7 +60,7 @@ class FileFormatTests: XCTestCase {
 
     // MARK: Image Representation
 
-    private func assertRoundTrip(format: FileFormat, file: StaticString = #file, line: UInt = #line) throws {
+    private func assertRoundTrip(format: FileFormat, file: StaticString = #filePath, line: UInt = #line) throws {
         let image = makeTestImage()
         let data = try XCTUnwrap(image.imageRepresentation(for: format) as Data?, "no data produced for \(format)", file: file, line: line)
         XCTAssertGreaterThan(data.count, 0, "\(format) data is empty", file: file, line: line)

--- a/Tests/duotoneTests/ProcessTests.swift
+++ b/Tests/duotoneTests/ProcessTests.swift
@@ -1,0 +1,86 @@
+//
+//  ProcessTests.swift
+//  duotoneTests
+//
+
+import XCTest
+@testable import duotone
+
+class ProcessTests: XCTestCase {
+
+    // Required args (inputPath, --out) are passed but unused by resolvePreset(from:).
+    private func parseProcess(_ extra: [String]) throws -> Duotone.Process {
+        try Duotone.Process.parse(["dummy.jpg", "--out", "out"] + extra)
+    }
+
+    // MARK: Named preset
+
+    func testResolvePreset_namedPresetFound() throws {
+        let pool = [
+            Preset(name: "spacegray", light: "#444644", dark: "#1E201E", contrast: 0.5, blend: 1.0, description: nil),
+            Preset(name: "duke", light: "#FFCB00", dark: "#38046C", contrast: 0.4, blend: 0.75, description: nil)
+        ]
+        let process = try self.parseProcess(["-p", "duke"])
+        let resolved = try process.resolvePreset(from: pool)
+        XCTAssertEqual(resolved.name, "duke")
+        XCTAssertEqual(resolved.contrast, 0.4)
+        XCTAssertEqual(resolved.blend, 0.75)
+    }
+
+    func testResolvePreset_namedPresetNotFound_throws() throws {
+        let process = try self.parseProcess(["-p", "missing"])
+        XCTAssertThrowsError(try process.resolvePreset(from: []))
+    }
+
+    func testResolvePreset_namedPresetNotFoundInNonEmptyPool_throws() throws {
+        let pool = [Preset(name: "duke", light: "#FFCB00", dark: "#38046C", contrast: 0.5, blend: 1.0, description: nil)]
+        let process = try self.parseProcess(["-p", "missing"])
+        XCTAssertThrowsError(try process.resolvePreset(from: pool))
+    }
+
+    // MARK: CLI hex path
+
+    func testResolvePreset_cliHex_defaultsContrastAndBlend() throws {
+        let process = try self.parseProcess(["-l", "#FFFFFF", "-d", "#000000"])
+        let resolved = try process.resolvePreset(from: [])
+        XCTAssertEqual(resolved.name, "cli")
+        XCTAssertEqual(resolved.light, "#FFFFFF")
+        XCTAssertEqual(resolved.dark, "#000000")
+        XCTAssertEqual(resolved.contrast, 0.5)
+        XCTAssertEqual(resolved.blend, 1.0)
+    }
+
+    func testResolvePreset_cliHex_explicitContrastAndBlend() throws {
+        let process = try self.parseProcess([
+            "-l", "#FFFFFF",
+            "-d", "#000000",
+            "-c", "0.25",
+            "-b", "0.75"
+        ])
+        let resolved = try process.resolvePreset(from: [])
+        XCTAssertEqual(resolved.contrast, 0.25)
+        XCTAssertEqual(resolved.blend, 0.75)
+    }
+
+    func testResolvePreset_cliHex_clampsContrastAndBlend() throws {
+        let process = try self.parseProcess([
+            "-l", "#FFFFFF",
+            "-d", "#000000",
+            "--contrast=2.0",
+            "--blend=-1.0"
+        ])
+        let resolved = try process.resolvePreset(from: [])
+        XCTAssertEqual(resolved.contrast, 1.0)
+        XCTAssertEqual(resolved.blend, 0.0)
+    }
+
+    func testResolvePreset_cliHex_missingLight_throws() throws {
+        let process = try self.parseProcess(["-d", "#000000"])
+        XCTAssertThrowsError(try process.resolvePreset(from: []))
+    }
+
+    func testResolvePreset_cliHex_missingDark_throws() throws {
+        let process = try self.parseProcess(["-l", "#FFFFFF"])
+        XCTAssertThrowsError(try process.resolvePreset(from: []))
+    }
+}

--- a/Tests/duotoneTests/ProcessTests.swift
+++ b/Tests/duotoneTests/ProcessTests.swift
@@ -7,10 +7,33 @@ import XCTest
 @testable import duotone
 
 class ProcessTests: XCTestCase {
+    private var tempDir: String = ""
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = "\(NSTemporaryDirectory())duotone-process-tests-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: tempDir)
+        try super.tearDownWithError()
+    }
+
+    private func writeFile(name: String, in dir: String? = nil) throws -> String {
+        let parent = dir ?? self.tempDir
+        let path = "\(parent)/\(name)"
+        try Data().write(to: URL(fileURLWithPath: path))
+        return path
+    }
 
     // Required args (inputPath, --out) are passed but unused by resolvePreset(from:).
     private func parseProcess(_ extra: [String]) throws -> Duotone.Process {
         try Duotone.Process.parse(["dummy.jpg", "--out", "out"] + extra)
+    }
+
+    private func parseProcess(inputPath: String, _ extra: [String] = []) throws -> Duotone.Process {
+        try Duotone.Process.parse([inputPath, "--out", "out"] + extra)
     }
 
     // MARK: Named preset
@@ -82,5 +105,58 @@ class ProcessTests: XCTestCase {
     func testResolvePreset_cliHex_missingDark_throws() throws {
         let process = try self.parseProcess(["-l", "#FFFFFF"])
         XCTAssertThrowsError(try process.resolvePreset(from: []))
+    }
+
+    // MARK: processInput
+
+    func testProcessInput_singleFileWithValidExtension_returnsThatFile() throws {
+        let path = try self.writeFile(name: "image.png")
+        let process = try self.parseProcess(inputPath: path)
+        let files = try process.processInput()
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files[0].name, "image.png")
+    }
+
+    func testProcessInput_singleFileWithJpegAlias_returnsThatFile() throws {
+        let path = try self.writeFile(name: "image.jpeg")
+        let process = try self.parseProcess(inputPath: path)
+        let files = try process.processInput()
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files[0].name, "image.jpeg")
+    }
+
+    func testProcessInput_singleFileWithInvalidExtension_throws() throws {
+        let path = try self.writeFile(name: "notes.txt")
+        let process = try self.parseProcess(inputPath: path)
+        XCTAssertThrowsError(try process.processInput())
+    }
+
+    func testProcessInput_folder_returnsOnlyValidFormatFiles() throws {
+        _ = try self.writeFile(name: "a.png")
+        _ = try self.writeFile(name: "b.jpg")
+        _ = try self.writeFile(name: "ignore.txt")
+        _ = try self.writeFile(name: "readme.md")
+        let process = try self.parseProcess(inputPath: tempDir)
+        let files = try process.processInput()
+        let names = Set(files.map(\.name))
+        XCTAssertEqual(names, Set(["a.png", "b.jpg"]))
+    }
+
+    func testProcessInput_folderWithNoSupportedFiles_returnsEmpty() throws {
+        _ = try self.writeFile(name: "ignore.txt")
+        let process = try self.parseProcess(inputPath: tempDir)
+        let files = try process.processInput()
+        XCTAssertEqual(files.count, 0)
+    }
+
+    func testProcessInput_emptyFolder_returnsEmpty() throws {
+        let process = try self.parseProcess(inputPath: tempDir)
+        let files = try process.processInput()
+        XCTAssertEqual(files.count, 0)
+    }
+
+    func testProcessInput_nonExistentPath_throws() throws {
+        let process = try self.parseProcess(inputPath: "\(tempDir)/does-not-exist")
+        XCTAssertThrowsError(try process.processInput())
     }
 }


### PR DESCRIPTION
## Summary
- Lift line coverage 31% → 49%, regions 30% → 53%, functions 33% → 63%
- Add 29 new tests (28 → 57) covering preset CRUD, Process argument resolution, and input-path scanning
- Refactor three call sites to expose pure logic for testing without touching `~/.duotone` or stdout

## Highlights

**New test files**
- `ClampedTests` — covers `Comparable.clamped(to:)` (was 0%, now 100%) across within/below/above/boundary cases for both Float and Int.
- `AddRemoveTests` — drives `Duotone.Add.addingPreset(to:)` and `Duotone.Remove.removingPreset(from:)` through their success paths, the duplicate-name and not-found error paths, contrast/blend clamping, description persistence, and invalid-hex rejection.
- `ProcessTests` — covers `Process.resolvePreset(from:)` (named-preset success/missing, CLI hex defaults/explicit/clamped, missing light/dark) and `Process.processInput()` (single file with valid/invalid extension, folder filtering, empty folder, non-existent path).

**Refactors to enable testing**
- Split disk I/O from list mutation in `Add.run()`/`Remove.run()` by introducing `addingPreset(to:)`/`removingPreset(from:)` helpers. The `run()` orchestrators are unchanged in behavior.
- Split disk I/O from preset resolution in `Process.preset()` by introducing `resolvePreset(from:)`. The private `preset()` wrapper now just loads `~/.duotone` and forwards.
- Drop `private` from `Process.processInput()` so tests can drive its branches directly with `NSTemporaryDirectory()` fixtures.

**Cleanup**
- Replace `#file` with `#filePath` in the `FileFormatTests.assertRoundTrip` helper, silencing six long-form warnings on every XCTest assertion call site.

## Coverage by file (before → after)

| File | Lines |
|---|---|
| `Comparable+Clamped.swift` | 0% → **100%** |
| `FileFormats.swift` | 89% → **98%** |
| `Presets/Add.swift` | 0% → **79%** |
| `Presets/Remove.swift` | 0% → **57%** |
| `Duotone.swift` | 1% → **39%** |

`ImageProcessor.swift`, `MTLTexture+CGImage.swift`, and `Process.run()`/`Process.process()` remain uncovered — Metal-tied code is intentionally not tested per `CLAUDE.md` (golden-image tests are flaky across hardware). `List.run()` and the `Loader` no-arg defaults are also uncovered; testing them would require stdout capture and `\$HOME` overrides for trivial wrapper code.

## Test plan
- [x] `swift test` — 57/57 pass
- [x] `swiftlint --strict` — 0 violations
- [x] No new compiler warnings introduced (existing `#file` warnings cleaned up)
- [ ] CI runs green on push