### PR TITLE
Fix real-world CLI bugs surfaced by camera-dump processing

### DIFF
--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -13,7 +13,7 @@ struct DuotoneError: Error, CustomStringConvertible {
 struct Duotone: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for duotoning images.",
-        version: "1.1.1",
+        version: "1.1.2",
         subcommands: [Process.self, Add.self, Remove.self, List.self],
         defaultSubcommand: Process.self)
 }

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -132,14 +132,14 @@ extension Duotone {
 
         func processInput() throws -> [File] {
             if let file = try? File(path: inputPath) {
-                if let ext = file.extension, FileFormat.allValidExtensions.contains(ext) {
+                if let ext = file.extension, FileFormat(rawValue: ext) != nil {
                     return [file]
                 }
                 throw ValidationError("\(file.name) is not a valid image format.")
             } else {
                 var inputFiles = [File]()
                 for file in try Folder(path: inputPath).files {
-                    if let ext = file.extension, FileFormat.allValidExtensions.contains(ext) {
+                    if let ext = file.extension, FileFormat(rawValue: ext) != nil {
                         inputFiles.append(file)
                     }
                 }

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -102,6 +102,7 @@ extension Duotone {
             let lightColor = try NSColor(hex: preset.light)
             let darkColor = try NSColor(hex: preset.dark)
 
+            try FileManager.default.createDirectory(atPath: outputPath, withIntermediateDirectories: true)
             let outputFolder = try Folder(path: outputPath)
             let processor = try ImageProcessor()
             for (index, file) in imagePaths.enumerated() {

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -102,8 +102,9 @@ extension Duotone {
             let lightColor = try NSColor(hex: preset.light)
             let darkColor = try NSColor(hex: preset.dark)
 
-            try FileManager.default.createDirectory(atPath: outputPath, withIntermediateDirectories: true)
-            let outputFolder = try Folder(path: outputPath)
+            let resolvedOutputPath = NSString(string: outputPath).expandingTildeInPath
+            try FileManager.default.createDirectory(atPath: resolvedOutputPath, withIntermediateDirectories: true)
+            let outputFolder = try Folder(path: resolvedOutputPath)
             let processor = try ImageProcessor()
             for (index, file) in imagePaths.enumerated() {
                 if verbose {

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -43,6 +43,9 @@ extension Duotone {
         @Flag(name: .shortAndLong, help: "Print verbose output")
         var verbose = false
 
+        @Flag(name: .long, help: "Stop on the first failed image instead of skipping it")
+        var strict = false
+
         @Option(name: [.short, .customLong("out")], help: "Path where the output files are saved")
         var outputPath: String
 
@@ -106,28 +109,43 @@ extension Duotone {
             try FileManager.default.createDirectory(atPath: resolvedOutputPath, withIntermediateDirectories: true)
             let outputFolder = try Folder(path: resolvedOutputPath)
             let processor = try ImageProcessor()
+            var succeeded = 0
+            var skippedCount = 0
             for (index, file) in imagePaths.enumerated() {
                 if verbose {
                     print("- [\(index + 1)/\(imagePaths.count)] Processing: \(file.name)")
                 }
 
-                guard let ext = file.extension,
-                      let format = FileFormat(rawValue: ext),
-                      let inputImage = NSImage(contentsOfFile: file.path)
-                else {
-                    throw ValidationError("Failed to load \(file.name)")
+                do {
+                    guard let ext = file.extension,
+                          let format = FileFormat(rawValue: ext),
+                          let inputImage = NSImage(contentsOfFile: file.path)
+                    else {
+                        throw ValidationError("Failed to load \(file.name)")
+                    }
+                    let outputImage = try processor.colorMap(inputImage,
+                                                             darkColor: darkColor,
+                                                             lightColor: lightColor,
+                                                             contrast: preset.contrast,
+                                                             blend: preset.blend)
+                    guard let outputData = outputImage.imageRepresentation(for: format) as Data? else {
+                        throw ValidationError("Failed to save '\(file.name)'")
+                    }
+                    try outputFolder.createFile(at: file.name, contents: outputData)
+                    succeeded += 1
+                } catch {
+                    if strict {
+                        throw error
+                    }
+                    skippedCount += 1
+                    FileHandle.standardError.write(Data("⚠️  Skipped \(file.name): \(error)\n".utf8))
                 }
-
-                let outputImage = try processor.colorMap(inputImage,
-                                                         darkColor: darkColor,
-                                                         lightColor: lightColor,
-                                                         contrast: preset.contrast,
-                                                         blend: preset.blend)
-                guard let outputData = outputImage.imageRepresentation(for: format) as Data? else {
-                    throw ValidationError("Failed to save '\(file.name)'")
-                }
-
-                try outputFolder.createFile(at: file.name, contents: outputData)
+            }
+            if succeeded == 0 {
+                throw ValidationError("All \(imagePaths.count) image(s) failed to process.")
+            }
+            if verbose, skippedCount > 0 {
+                print("⚠️  Skipped \(skippedCount) of \(imagePaths.count) image(s).")
             }
             return outputFolder
         }

--- a/Sources/duotone/Extensions/NSColor+Hex.swift
+++ b/Sources/duotone/Extensions/NSColor+Hex.swift
@@ -16,7 +16,8 @@ public extension NSColor {
         }
 
         var rgbValue: UInt64 = 0
-        guard Scanner(string: hexFormatted).scanHexInt64(&rgbValue) else {
+        let scanner = Scanner(string: hexFormatted)
+        guard scanner.scanHexInt64(&rgbValue), scanner.isAtEnd else {
             throw DuotoneError("\(hex) is not a valid hex color.")
         }
 

--- a/Sources/duotone/Presets/Add.swift
+++ b/Sources/duotone/Presets/Add.swift
@@ -11,7 +11,7 @@ import Files
 
 extension Duotone {
     struct Add: ParsableCommand {
-        static let configuration = CommandConfiguration(abstract: "Add a presets.")
+        static let configuration = CommandConfiguration(abstract: "Add a preset.")
 
         @Option(name: .long, help: "The name of the preset")
         var preset: String

--- a/Sources/duotone/Presets/List.swift
+++ b/Sources/duotone/Presets/List.swift
@@ -16,7 +16,12 @@ extension Duotone {
         mutating func run() throws {
             let presets = try Duotone.loadPresets()
             for preset in presets {
-                print("Name: \(preset.name) - Light: \(preset.light), Dark: \(preset.dark), Contrast: \(preset.contrast), Blend: \(preset.blend)")
+                var line = "Name: \(preset.name) - Light: \(preset.light), Dark: \(preset.dark)"
+                line += ", Contrast: \(preset.contrast), Blend: \(preset.blend)"
+                if let description = preset.description, !description.isEmpty {
+                    line += " — \(description)"
+                }
+                print(line)
             }
         }
     }

--- a/Sources/duotone/Presets/Remove.swift
+++ b/Sources/duotone/Presets/Remove.swift
@@ -11,7 +11,7 @@ import Files
 
 extension Duotone {
     struct Remove: ParsableCommand {
-        static let configuration = CommandConfiguration(abstract: "Remove a presets.")
+        static let configuration = CommandConfiguration(abstract: "Remove a preset.")
 
         @Option(name: .long, help: "The name of the preset")
         var preset: String

--- a/Tests/duotoneTests/HexColorTests.swift
+++ b/Tests/duotoneTests/HexColorTests.swift
@@ -88,6 +88,17 @@ class HexColorTests: XCTestCase {
         XCTAssertThrowsError(try NSColor(hex: "helloo"))
     }
 
+    func testParsingWithMidStringNonHexThrows() throws {
+        // Regression: Scanner.scanHexInt64 returns true after consuming any leading
+        // hex digits, ignoring trailing garbage. Without an isAtEnd check, "badhex"
+        // silently produced #0000AD (rgbValue=0xBAD treated as a 6-char hex).
+        XCTAssertThrowsError(try NSColor(hex: "badhex"))
+        XCTAssertThrowsError(try NSColor(hex: "fxx"))   // 3-char branch
+        XCTAssertThrowsError(try NSColor(hex: "ax"))    // 2-char branch
+        XCTAssertThrowsError(try NSColor(hex: "fxxx"))  // 4-char branch
+        XCTAssertThrowsError(try NSColor(hex: "deadXXXX")) // 8-char branch
+    }
+
     func testParsingWithNakedValueHex() throws {
         let hexColor = "1A752154"
 

--- a/Tests/duotoneTests/ProcessTests.swift
+++ b/Tests/duotoneTests/ProcessTests.swift
@@ -183,7 +183,7 @@ class ProcessTests: XCTestCase {
         XCTAssertThrowsError(try process.processInput())
     }
 
-    // MARK: --strict flag
+    // MARK: Strict flag
 
     func testStrictFlag_defaultsToFalse() throws {
         let process = try self.parseProcess(["-l", "#FFFFFF", "-d", "#000000"])

--- a/Tests/duotoneTests/ProcessTests.swift
+++ b/Tests/duotoneTests/ProcessTests.swift
@@ -182,4 +182,16 @@ class ProcessTests: XCTestCase {
         let process = try self.parseProcess(inputPath: "\(tempDir)/does-not-exist")
         XCTAssertThrowsError(try process.processInput())
     }
+
+    // MARK: --strict flag
+
+    func testStrictFlag_defaultsToFalse() throws {
+        let process = try self.parseProcess(["-l", "#FFFFFF", "-d", "#000000"])
+        XCTAssertFalse(process.strict)
+    }
+
+    func testStrictFlag_setsToTrueWhenPassed() throws {
+        let process = try self.parseProcess(["-l", "#FFFFFF", "-d", "#000000", "--strict"])
+        XCTAssertTrue(process.strict)
+    }
 }

--- a/Tests/duotoneTests/ProcessTests.swift
+++ b/Tests/duotoneTests/ProcessTests.swift
@@ -125,6 +125,29 @@ class ProcessTests: XCTestCase {
         XCTAssertEqual(files[0].name, "image.jpeg")
     }
 
+    func testProcessInput_singleFileWithUppercaseExtension_returnsThatFile() throws {
+        // Regression: real-world camera output uses .JPG (uppercase). The previous
+        // implementation matched extensions case-sensitively and rejected these.
+        let path = try self.writeFile(name: "image.JPG")
+        let process = try self.parseProcess(inputPath: path)
+        let files = try process.processInput()
+        XCTAssertEqual(files.count, 1)
+        XCTAssertEqual(files[0].name, "image.JPG")
+    }
+
+    func testProcessInput_folderWithUppercaseExtensions_returnsThoseFiles() throws {
+        // Regression: the folder branch silently dropped uppercase-extension files,
+        // leaving callers with "No images found" on perfectly valid input.
+        _ = try self.writeFile(name: "a.JPG")
+        _ = try self.writeFile(name: "b.PNG")
+        _ = try self.writeFile(name: "c.TIFF")
+        _ = try self.writeFile(name: "ignore.txt")
+        let process = try self.parseProcess(inputPath: tempDir)
+        let files = try process.processInput()
+        let names = Set(files.map(\.name))
+        XCTAssertEqual(names, Set(["a.JPG", "b.PNG", "c.TIFF"]))
+    }
+
     func testProcessInput_singleFileWithInvalidExtension_throws() throws {
         let path = try self.writeFile(name: "notes.txt")
         let process = try self.parseProcess(inputPath: path)


### PR DESCRIPTION
## Summary
- Fix four real bugs surfaced by running the CLI on a real folder of camera-output JPEGs (uppercase `.JPG`, missing output folder, tilde paths, hex parser leniency)
- Replace fail-fast batch behavior with skip-and-warn; add `--strict` flag as a compatibility hatch for the old behavior
- Polish two minor things found during the survey
- Bump to v1.1.2 — bug fixes dominate; `--strict` is a back-compat hatch, not a headline feature

## Bugs fixed

**Case-sensitive extension matching dropped uppercase files** (`4d2339b`) — `Process.processInput()` compared raw file extensions against the all-lowercase `FileFormat.allValidExtensions`. A folder of 136 `.JPG` files (typical camera output) was silently filtered to empty, producing `Error: No images found`. A single uppercase `.JPG` hit the other branch and threw `is not a valid image format`. Switched to `FileFormat(rawValue: ext) != nil`, which already lowercases internally — same matcher used for format resolution a few lines down.

**`--out` folder must already exist** (`8fc8c1a`) — `Folder(path:)` from the Files library throws `missing` when the path doesn't exist, forcing users to `mkdir` before every invocation. Now created on demand with intermediate-directory support so nested `--out ./out/2026` works too.

**Tilde not expanded in `--out`** (`e0262b4`) — regression introduced by the previous fix. `FileManager.createDirectory` doesn't expand `~` the way `Folder(path:)` does, so `--out '~/foo'` created a literal `./~/foo` directory. Resolved once via `NSString.expandingTildeInPath` (matches the pattern in `Loader.swift`) and used the resolved string for both calls.

**Hex parser silently accepted strings with mid-string non-hex chars** (`1b970ab`) — `Scanner.scanHexInt64` returns true after consuming any leading hex digits, ignoring trailing garbage. The 6-char branch quietly converted `badhex` → `#0000AD` (rgbValue=0xBAD), `fxx` → `#0000FF` (3-char branch), etc. Added `scanner.isAtEnd` check after the scan so the entire input must be valid hex.

## Behavior change

**Skip-and-warn default for batch processing; `--strict` for fail-fast** (`259ff6f`) — previously a single corrupt or unreadable image aborted the entire batch, discarding any already-written outputs. For folder runs of camera dumps that's destructive — one stray zero-byte upload kills hours of processing. New default reports each failure on stderr (`⚠️  Skipped <name>: <reason>`) and continues. The run exits non-zero only when zero images succeed, which preserves single-file failure semantics. Added `--strict` for scripts that need fail-fast.

## Polish

- `duotone list` now displays the stored `description` field (was silently omitted)
- `Add` and `Remove` subcommand abstracts: "Add a presets" → "Add a preset", same for Remove

## Test plan
- [x] `swift test` — 62/62 pass
- [x] `swiftlint --strict` — 0 violations
- [x] Real-world: re-ran the original failing command (`duotone ~/Desktop/123 --light '#FFCB00' --dark '#38046C' --out ./out`) and verified all 136 files were processed
- [x] Confirmed `--strict` correctly aborts on first failure
- [x] Confirmed default skips bad files and continues
- [x] Confirmed `--out '~/foo'` now expands correctly (no literal `./~/foo` dir created)
- [x] Confirmed `badhex`, `fxx`, `deadXXXX` etc. are now rejected
- [x] Smoke-tested TIFF, BMP, JPEG round-trips, symlinked input, in-place overwrite, paths with spaces, nested `--out`, all preset CRUD, missing-arg validation, exit codes
- [ ] CI runs green on push