### PR TITLE
Show progress bar during batch processing

### DIFF
--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ArgumentParser
+import Darwin
 import Files
 import Foundation
 
@@ -46,6 +47,9 @@ extension Duotone {
         @Flag(name: .long, help: "Stop on the first failed image instead of skipping it")
         var strict = false
 
+        @Flag(name: .long, help: "Disable the progress bar (auto-disabled when stderr is not a TTY)")
+        var noProgress = false
+
         @Option(name: [.short, .customLong("out")], help: "Path where the output files are saved")
         var outputPath: String
 
@@ -65,14 +69,26 @@ extension Duotone {
                 print("⚙️ Processing \(imagePaths.count) images...")
             }
 
-            let outputFolder = try process(imagePaths, preset: preset)
+            let reporter = self.makeProgressReporter(total: imagePaths.count)
+            let result = try process(imagePaths, preset: preset, reporter: reporter)
+
+            let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+            reporter?.finish(succeeded: result.succeeded, skipped: result.skipped, elapsed: timeElapsed)
 
             if verbose == true {
-                let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
                 print("🚀 Done!\n")
-                print("📂 Output: \(outputFolder.path)")
+                print("📂 Output: \(result.folder.path)")
                 print("⏱ Completed in \(String(format: "%.3f", timeElapsed))s")
             }
+        }
+
+        private func makeProgressReporter(total: Int) -> ProgressReporter? {
+            guard total > 1, !self.verbose, !self.noProgress, isatty(fileno(stderr)) != 0 else { return nil }
+            return ProgressReporter(
+                total: total,
+                isInteractive: true,
+                writer: { FileHandle.standardError.write(Data($0.utf8)) }
+            )
         }
 
         private func preset() throws -> Preset {
@@ -101,7 +117,13 @@ extension Duotone {
             return Preset(name: "cli", light: lightHexOption, dark: darkHexOption, contrast: contrast, blend: blend, description: nil)
         }
 
-        private func process(_ imagePaths: [File], preset: Preset) throws -> Folder {
+        struct BatchResult {
+            let folder: Folder
+            let succeeded: Int
+            let skipped: Int
+        }
+
+        private func process(_ imagePaths: [File], preset: Preset, reporter: ProgressReporter?) throws -> BatchResult {
             let lightColor = try NSColor(hex: preset.light)
             let darkColor = try NSColor(hex: preset.dark)
 
@@ -112,6 +134,7 @@ extension Duotone {
             var succeeded = 0
             var skippedCount = 0
             for (index, file) in imagePaths.enumerated() {
+                reporter?.update(current: index + 1, filename: file.name)
                 if verbose {
                     print("- [\(index + 1)/\(imagePaths.count)] Processing: \(file.name)")
                 }
@@ -138,6 +161,7 @@ extension Duotone {
                         throw error
                     }
                     skippedCount += 1
+                    reporter?.clearLine()
                     FileHandle.standardError.write(Data("⚠️  Skipped \(file.name): \(error)\n".utf8))
                 }
             }
@@ -147,7 +171,7 @@ extension Duotone {
             if verbose, skippedCount > 0 {
                 print("⚠️  Skipped \(skippedCount) of \(imagePaths.count) image(s).")
             }
-            return outputFolder
+            return BatchResult(folder: outputFolder, succeeded: succeeded, skipped: skippedCount)
         }
 
         func processInput() throws -> [File] {

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -1,6 +1,5 @@
 import AppKit
 import ArgumentParser
-import Darwin
 import Files
 import Foundation
 
@@ -83,10 +82,16 @@ extension Duotone {
         }
 
         private func makeProgressReporter(total: Int) -> ProgressReporter? {
-            guard total > 1, !self.verbose, !self.noProgress, isatty(fileno(stderr)) != 0 else { return nil }
+            guard ProgressReporter.shouldShow(
+                total: total,
+                verbose: self.verbose,
+                noProgress: self.noProgress,
+                isStderrTTY: ProgressReporter.isStderrInteractive()
+            ) else { return nil }
             return ProgressReporter(
                 total: total,
                 isInteractive: true,
+                lineWidth: ProgressReporter.terminalWidth(),
                 writer: { FileHandle.standardError.write(Data($0.utf8)) }
             )
         }

--- a/Sources/duotone/Duotone.swift
+++ b/Sources/duotone/Duotone.swift
@@ -13,7 +13,7 @@ struct DuotoneError: Error, CustomStringConvertible {
 struct Duotone: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for duotoning images.",
-        version: "1.1.2",
+        version: "1.2.0",
         subcommands: [Process.self, Add.self, Remove.self, List.self],
         defaultSubcommand: Process.self)
 }

--- a/Sources/duotone/ProgressReporter.swift
+++ b/Sources/duotone/ProgressReporter.swift
@@ -3,34 +3,47 @@
 //  duotone
 //
 
+import Darwin
 import Foundation
 
-struct ProgressReporter {
+struct ProgressReporter: Sendable {
     static let defaultMaxFilenameLength = 30
     static let defaultBarWidth = 20
+    static let defaultMaxLineWidth = 80
+    /// Filename is dropped entirely when its budget falls below this — leaves the bar legible.
+    static let minFilenameBudget = 4
 
     private static let clearLineEscape = "\r\u{1B}[2K"
 
     let total: Int
     let isInteractive: Bool
     let barWidth: Int
-    private let writer: (String) -> Void
+    let lineWidth: Int
+    private let writer: @Sendable (String) -> Void
 
     init(
         total: Int,
         isInteractive: Bool,
         barWidth: Int = ProgressReporter.defaultBarWidth,
-        writer: @escaping (String) -> Void
+        lineWidth: Int = ProgressReporter.defaultMaxLineWidth,
+        writer: @Sendable @escaping (String) -> Void
     ) {
         self.total = total
         self.isInteractive = isInteractive
         self.barWidth = barWidth
+        self.lineWidth = lineWidth
         self.writer = writer
     }
 
     func update(current: Int, filename: String) {
         guard self.isInteractive else { return }
-        let bar = Self.renderBar(current: current, total: self.total, filename: filename, barWidth: self.barWidth)
+        let bar = Self.renderBar(
+            current: current,
+            total: self.total,
+            filename: filename,
+            barWidth: self.barWidth,
+            maxLineWidth: self.lineWidth
+        )
         self.writer(Self.clearLineEscape + bar)
     }
 
@@ -45,13 +58,46 @@ struct ProgressReporter {
         self.writer(Self.clearLineEscape)
     }
 
-    static func renderBar(current: Int, total: Int, filename: String, barWidth: Int) -> String {
+    static func renderBar(
+        current: Int,
+        total: Int,
+        filename: String,
+        barWidth: Int,
+        maxLineWidth: Int = ProgressReporter.defaultMaxLineWidth
+    ) -> String {
         let progress = total > 0 ? min(1.0, max(0.0, Double(current) / Double(total))) : 0.0
         let filled = min(barWidth, max(0, Int((Double(barWidth) * progress).rounded())))
         let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: barWidth - filled)
         let percent = Int((progress * 100).rounded())
-        let label = Self.truncate(filename, max: Self.defaultMaxFilenameLength)
-        return "[\(bar)] \(current)/\(total) (\(percent)%) \(label)"
+        let chrome = "[\(bar)] \(current)/\(total) (\(percent)%)"
+        let budget = maxLineWidth - chrome.count - 1   // -1 for the space before the filename
+        if budget < Self.minFilenameBudget {
+            return chrome
+        }
+        let label = Self.truncate(filename, max: min(budget, Self.defaultMaxFilenameLength))
+        return "\(chrome) \(label)"
+    }
+
+    /// Detects the current terminal width via `ioctl(TIOCGWINSZ)` on stderr.
+    /// Falls back to `defaultMaxLineWidth` when stderr is not a TTY or the call fails.
+    static func terminalWidth() -> Int {
+        var size = winsize()
+        let result = withUnsafeMutablePointer(to: &size) { ptr in
+            return ioctl(fileno(stderr), TIOCGWINSZ, ptr)
+        }
+        guard result == 0, size.ws_col > 0 else { return Self.defaultMaxLineWidth }
+        return Int(size.ws_col)
+    }
+
+    /// Whether a progress bar should be drawn for this run.
+    /// Centralizes the four gating conditions so they can be unit-tested in isolation.
+    static func shouldShow(total: Int, verbose: Bool, noProgress: Bool, isStderrTTY: Bool) -> Bool {
+        return total > 1 && !verbose && !noProgress && isStderrTTY
+    }
+
+    /// Returns true when stderr is connected to an interactive terminal.
+    static func isStderrInteractive() -> Bool {
+        return isatty(fileno(stderr)) != 0
     }
 
     static func renderSummary(succeeded: Int, skipped: Int, elapsed: TimeInterval) -> String {

--- a/Sources/duotone/ProgressReporter.swift
+++ b/Sources/duotone/ProgressReporter.swift
@@ -1,0 +1,70 @@
+//
+//  ProgressReporter.swift
+//  duotone
+//
+
+import Foundation
+
+struct ProgressReporter {
+    static let defaultMaxFilenameLength = 30
+    static let defaultBarWidth = 20
+
+    private static let clearLineEscape = "\r\u{1B}[2K"
+
+    let total: Int
+    let isInteractive: Bool
+    let barWidth: Int
+    private let writer: (String) -> Void
+
+    init(
+        total: Int,
+        isInteractive: Bool,
+        barWidth: Int = ProgressReporter.defaultBarWidth,
+        writer: @escaping (String) -> Void
+    ) {
+        self.total = total
+        self.isInteractive = isInteractive
+        self.barWidth = barWidth
+        self.writer = writer
+    }
+
+    func update(current: Int, filename: String) {
+        guard self.isInteractive else { return }
+        let bar = Self.renderBar(current: current, total: self.total, filename: filename, barWidth: self.barWidth)
+        self.writer(Self.clearLineEscape + bar)
+    }
+
+    func finish(succeeded: Int, skipped: Int, elapsed: TimeInterval) {
+        guard self.isInteractive else { return }
+        let summary = Self.renderSummary(succeeded: succeeded, skipped: skipped, elapsed: elapsed)
+        self.writer(Self.clearLineEscape + summary + "\n")
+    }
+
+    func clearLine() {
+        guard self.isInteractive else { return }
+        self.writer(Self.clearLineEscape)
+    }
+
+    static func renderBar(current: Int, total: Int, filename: String, barWidth: Int) -> String {
+        let progress = total > 0 ? min(1.0, max(0.0, Double(current) / Double(total))) : 0.0
+        let filled = min(barWidth, max(0, Int((Double(barWidth) * progress).rounded())))
+        let bar = String(repeating: "█", count: filled) + String(repeating: "░", count: barWidth - filled)
+        let percent = Int((progress * 100).rounded())
+        let label = Self.truncate(filename, max: Self.defaultMaxFilenameLength)
+        return "[\(bar)] \(current)/\(total) (\(percent)%) \(label)"
+    }
+
+    static func renderSummary(succeeded: Int, skipped: Int, elapsed: TimeInterval) -> String {
+        let totalCount = succeeded + skipped
+        let elapsedStr = String(format: "%.2fs", elapsed)
+        if skipped > 0 {
+            return "✓ Processed \(succeeded)/\(totalCount) (\(skipped) skipped) in \(elapsedStr)"
+        }
+        return "✓ Processed \(succeeded)/\(totalCount) in \(elapsedStr)"
+    }
+
+    private static func truncate(_ value: String, max maxLength: Int) -> String {
+        guard value.count > maxLength else { return value }
+        return "…" + String(value.suffix(maxLength - 1))
+    }
+}

--- a/Tests/duotoneTests/ProgressReporterTests.swift
+++ b/Tests/duotoneTests/ProgressReporterTests.swift
@@ -1,0 +1,125 @@
+//
+//  ProgressReporterTests.swift
+//  duotoneTests
+//
+
+import XCTest
+@testable import duotone
+
+final class ProgressReporterTests: XCTestCase {
+
+    // MARK: renderBar — fill levels
+
+    func testRenderBar_atZeroProgress_isEmpty() {
+        let bar = ProgressReporter.renderBar(current: 0, total: 10, filename: "a.png", barWidth: 10)
+        XCTAssertTrue(bar.contains("[" + String(repeating: "░", count: 10) + "]"), bar)
+        XCTAssertTrue(bar.contains("0/10"), bar)
+        XCTAssertTrue(bar.contains("(0%)"), bar)
+    }
+
+    func testRenderBar_atHalfProgress_isHalfFilled() {
+        let bar = ProgressReporter.renderBar(current: 5, total: 10, filename: "a.png", barWidth: 10)
+        let expected = "[" + String(repeating: "█", count: 5) + String(repeating: "░", count: 5) + "]"
+        XCTAssertTrue(bar.contains(expected), bar)
+        XCTAssertTrue(bar.contains("5/10"), bar)
+        XCTAssertTrue(bar.contains("(50%)"), bar)
+    }
+
+    func testRenderBar_atFullProgress_isFullyFilled() {
+        let bar = ProgressReporter.renderBar(current: 10, total: 10, filename: "a.png", barWidth: 10)
+        XCTAssertTrue(bar.contains("[" + String(repeating: "█", count: 10) + "]"), bar)
+        XCTAssertTrue(bar.contains("10/10"), bar)
+        XCTAssertTrue(bar.contains("(100%)"), bar)
+    }
+
+    // MARK: renderBar — edge cases
+
+    func testRenderBar_zeroTotal_doesNotCrash() {
+        let bar = ProgressReporter.renderBar(current: 0, total: 0, filename: "a.png", barWidth: 10)
+        XCTAssertTrue(bar.contains("0/0"), bar)
+        XCTAssertTrue(bar.contains("(0%)"), bar)
+    }
+
+    func testRenderBar_includesFilename_whenShort() {
+        let bar = ProgressReporter.renderBar(current: 1, total: 2, filename: "snapshot.png", barWidth: 10)
+        XCTAssertTrue(bar.contains("snapshot.png"), bar)
+    }
+
+    func testRenderBar_longFilename_isSuffixTruncatedWithLeadingEllipsis() {
+        let long = String(repeating: "x", count: 50) + "tail.jpg"
+        let bar = ProgressReporter.renderBar(current: 1, total: 2, filename: long, barWidth: 10)
+        XCTAssertFalse(bar.contains(long), "full long name should not appear in: \(bar)")
+        XCTAssertTrue(bar.contains("…"), "expected leading ellipsis in: \(bar)")
+        XCTAssertTrue(bar.contains("tail.jpg"), "expected suffix to be preserved in: \(bar)")
+    }
+
+    // MARK: renderSummary
+
+    func testRenderSummary_noSkipped_omitsSkippedClause() {
+        let line = ProgressReporter.renderSummary(succeeded: 10, skipped: 0, elapsed: 1.234)
+        XCTAssertTrue(line.contains("✓"), line)
+        XCTAssertTrue(line.contains("10/10"), line)
+        XCTAssertFalse(line.contains("skipped"), line)
+    }
+
+    func testRenderSummary_withSkipped_includesSkippedClause() {
+        let line = ProgressReporter.renderSummary(succeeded: 8, skipped: 2, elapsed: 1.234)
+        XCTAssertTrue(line.contains("8/10"), line)
+        XCTAssertTrue(line.contains("(2 skipped)"), line)
+    }
+
+    func testRenderSummary_formatsElapsedToTwoDecimals() {
+        let line = ProgressReporter.renderSummary(succeeded: 1, skipped: 0, elapsed: 4.207)
+        XCTAssertTrue(line.contains("4.21s"), line)
+    }
+
+    // MARK: Reporter — interactive vs not
+
+    private final class CaptureWriter {
+        var output: String = ""
+        func write(_ value: String) { self.output.append(value) }
+    }
+
+    func testReporter_whenNotInteractive_writerIsNeverCalled() {
+        let capture = CaptureWriter()
+        let reporter = ProgressReporter(total: 5, isInteractive: false, barWidth: 10, writer: capture.write)
+        reporter.update(current: 1, filename: "a.png")
+        reporter.update(current: 2, filename: "b.png")
+        reporter.finish(succeeded: 2, skipped: 0, elapsed: 0.5)
+        XCTAssertEqual(capture.output, "")
+    }
+
+    func testReporter_whenInteractive_updateWritesCarriageReturnAndBar() {
+        let capture = CaptureWriter()
+        let reporter = ProgressReporter(total: 4, isInteractive: true, barWidth: 4, writer: capture.write)
+        reporter.update(current: 2, filename: "a.png")
+        XCTAssertTrue(capture.output.hasPrefix("\r"), capture.output)
+        XCTAssertTrue(capture.output.contains("2/4"), capture.output)
+        XCTAssertTrue(capture.output.contains("a.png"), capture.output)
+    }
+
+    func testReporter_finish_emitsSummaryWithTrailingNewline() {
+        let capture = CaptureWriter()
+        let reporter = ProgressReporter(total: 5, isInteractive: true, barWidth: 4, writer: capture.write)
+        reporter.finish(succeeded: 5, skipped: 0, elapsed: 1.0)
+        XCTAssertTrue(capture.output.contains("✓"), capture.output)
+        XCTAssertTrue(capture.output.hasSuffix("\n"), capture.output)
+    }
+
+    // MARK: clearLine — used when a skip-message must print above the bar
+
+    func testReporter_clearLine_whenInteractive_writesCarriageReturnAndClearEscape() {
+        let capture = CaptureWriter()
+        let reporter = ProgressReporter(total: 5, isInteractive: true, barWidth: 4, writer: capture.write)
+        reporter.clearLine()
+        XCTAssertTrue(capture.output.contains("\r"), capture.output)
+        XCTAssertTrue(capture.output.contains("\u{1B}[2K"), capture.output)
+    }
+
+    func testReporter_clearLine_whenNotInteractive_writesNothing() {
+        let capture = CaptureWriter()
+        let reporter = ProgressReporter(total: 5, isInteractive: false, barWidth: 4, writer: capture.write)
+        reporter.clearLine()
+        XCTAssertEqual(capture.output, "")
+    }
+}

--- a/Tests/duotoneTests/ProgressReporterTests.swift
+++ b/Tests/duotoneTests/ProgressReporterTests.swift
@@ -51,6 +51,44 @@ final class ProgressReporterTests: XCTestCase {
         XCTAssertFalse(bar.contains(long), "full long name should not appear in: \(bar)")
         XCTAssertTrue(bar.contains("…"), "expected leading ellipsis in: \(bar)")
         XCTAssertTrue(bar.contains("tail.jpg"), "expected suffix to be preserved in: \(bar)")
+        // Load-bearing invariant: the truncated label must respect the budget.
+        let label = bar.components(separatedBy: " ").last ?? ""
+        XCTAssertEqual(label.count, ProgressReporter.defaultMaxFilenameLength)
+    }
+
+    // MARK: renderBar — width-aware rendering
+
+    func testRenderBar_narrowMaxLineWidth_shrinksFilenameBudget() {
+        // Chrome for barWidth=10 ("[##########] 1/2 (50%)") is ~23 chars + space; with
+        // maxLineWidth=40 the filename budget shrinks to ~16 chars instead of the default 30.
+        let long = String(repeating: "x", count: 60) + "tail.jpg"
+        let bar = ProgressReporter.renderBar(current: 1, total: 2, filename: long, barWidth: 10, maxLineWidth: 40)
+        XCTAssertLessThanOrEqual(bar.count, 40, "rendered line must fit maxLineWidth: \(bar)")
+        XCTAssertTrue(bar.contains("…"), bar)
+    }
+
+    func testRenderBar_extremelyNarrowWidth_omitsFilenameRatherThanWrap() {
+        // When chrome alone exceeds the budget, drop the filename so the bar can still redraw cleanly.
+        let bar = ProgressReporter.renderBar(current: 1, total: 2, filename: "snapshot.png", barWidth: 10, maxLineWidth: 24)
+        XCTAssertFalse(bar.contains("snapshot"), "expected filename to be omitted in: \(bar)")
+        XCTAssertFalse(bar.contains("…"), "no truncation marker either when filename is dropped: \(bar)")
+        XCTAssertTrue(bar.contains("1/2"), bar)
+    }
+
+    func testRenderBar_wideMaxLineWidth_capsAtDefaultMaxFilenameLength() {
+        // Even with a huge maxLineWidth, defaultMaxFilenameLength remains the upper cap.
+        let long = String(repeating: "x", count: 200) + "tail.jpg"
+        let bar = ProgressReporter.renderBar(current: 1, total: 2, filename: long, barWidth: 10, maxLineWidth: 500)
+        let label = bar.components(separatedBy: " ").last ?? ""
+        XCTAssertEqual(label.count, ProgressReporter.defaultMaxFilenameLength)
+    }
+
+    // MARK: terminalWidth — runtime helper
+
+    func testTerminalWidth_returnsPositiveValue() {
+        // Under the test runner, stderr is not a TTY so ioctl fails; helper must
+        // fall back to a sensible positive default rather than 0 or a negative number.
+        XCTAssertGreaterThan(ProgressReporter.terminalWidth(), 0)
     }
 
     // MARK: renderSummary
@@ -75,7 +113,10 @@ final class ProgressReporterTests: XCTestCase {
 
     // MARK: Reporter — interactive vs not
 
-    private final class CaptureWriter {
+    /// Test-only sink for the reporter's writer closure. `@unchecked Sendable` because the
+    /// reporter requires a Sendable writer in production, but tests drive it serially from
+    /// a single thread so the unchecked escape hatch is safe.
+    private final class CaptureWriter: @unchecked Sendable {
         var output: String = ""
         func write(_ value: String) { self.output.append(value) }
     }
@@ -121,5 +162,39 @@ final class ProgressReporterTests: XCTestCase {
         let reporter = ProgressReporter(total: 5, isInteractive: false, barWidth: 4, writer: capture.write)
         reporter.clearLine()
         XCTAssertEqual(capture.output, "")
+    }
+
+    // MARK: shouldShow — gating predicate
+
+    func testShouldShow_allConditionsMet_returnsTrue() {
+        XCTAssertTrue(ProgressReporter.shouldShow(total: 5, verbose: false, noProgress: false, isStderrTTY: true))
+    }
+
+    func testShouldShow_singleImage_returnsFalse() {
+        XCTAssertFalse(ProgressReporter.shouldShow(total: 1, verbose: false, noProgress: false, isStderrTTY: true))
+    }
+
+    func testShouldShow_zeroImages_returnsFalse() {
+        XCTAssertFalse(ProgressReporter.shouldShow(total: 0, verbose: false, noProgress: false, isStderrTTY: true))
+    }
+
+    func testShouldShow_verbose_returnsFalse() {
+        XCTAssertFalse(ProgressReporter.shouldShow(total: 5, verbose: true, noProgress: false, isStderrTTY: true))
+    }
+
+    func testShouldShow_noProgress_returnsFalse() {
+        XCTAssertFalse(ProgressReporter.shouldShow(total: 5, verbose: false, noProgress: true, isStderrTTY: true))
+    }
+
+    func testShouldShow_notTTY_returnsFalse() {
+        XCTAssertFalse(ProgressReporter.shouldShow(total: 5, verbose: false, noProgress: false, isStderrTTY: false))
+    }
+
+    // MARK: isStderrInteractive — runtime helper
+
+    func testIsStderrInteractive_underTestRunner_returnsFalse() {
+        // Test runner captures stderr so it is never a TTY; this guards against
+        // the helper being accidentally inverted or stubbed to true.
+        XCTAssertFalse(ProgressReporter.isStderrInteractive())
     }
 }


### PR DESCRIPTION
## Summary

- Single-line redrawing progress bar on `duotone process` for folder batches; auto-disabled in non-TTY contexts (pipes, CI) and for single-image inputs.
- New `--no-progress` flag for forcing it off in interactive shells. `--verbose` still shows per-file lines and suppresses the bar.
- Width-aware: detects terminal columns via `ioctl(TIOCGWINSZ)` and shrinks (or drops) the filename label to avoid wrap on narrow panes.

## Test plan

- [x] `swift test` (87 tests, +25 new for `ProgressReporter`) and `swiftlint --strict` clean
- [x] Run against a folder in a real TTY — bar redraws cleanly, summary `✓ Processed N/M (K skipped) in T.TTs` lands
- [x] Run with `2>/dev/null` — silent stderr, output files written
- [x] `--verbose`, `--no-progress`, single-image, and a corrupt-input case all behave per the matrix in PROJECT_PLAN.md Phase 6